### PR TITLE
Make sure TwoPaneLayout only navigates when two panes are shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Helper functions that help you easily test your application on the dual-screen, 
 
 ## Social links
 
-- [video: Jetpack Compose WindowState preview](https://www.twitch.tv/videos/1271211220)
+- [video: Jetpack Compose WindowState preview](https://www.youtube.com/watch?v=qOIliow-uS4)
 - [blog: Jetpack Compose WindowState preview](https://devblogs.microsoft.com/surface-duo/jetpack-compose-windowstate-preview/)
 - [video: Get started with Jetpack Compose Twitch](https://www.youtube.com/watch?v=ijXDWDtdiIE)
 - [blog: Get started with Jetpack Compose](https://devblogs.microsoft.com/surface-duo/get-started-with-jetpack-compose/)

--- a/TwoPaneLayout/dependencies.gradle
+++ b/TwoPaneLayout/dependencies.gradle
@@ -22,7 +22,7 @@ ext {
 
     // ----------------------------------
 
-    gradlePluginVersion = '7.1.0'
+    gradlePluginVersion = '7.1.1'
     kotlinVersion = "1.6.10"
     compileSdkVersion = 31
     targetSdkVersion = compileSdkVersion
@@ -54,7 +54,7 @@ ext {
     ]
 
     // Compose dependencies
-    composeVersion = "1.1.0-rc03"
+    composeVersion = "1.1.0"
     activityComposeVersion = "1.4.0"
     navigationComposeVersion = "2.4.0"
     composeDependencies = [
@@ -83,7 +83,7 @@ ext {
     ]
 
     // Microsoft dependencies
-    windowStateVersion = '1.0.0-alpha02'
+    windowStateVersion = '1.0.0-alpha04'
     composeTestingVersion = '1.0.0-alpha01'
     microsoftDependencies = [
             windowState         : "com.microsoft.device.dualscreen:windowstate:$windowStateVersion",

--- a/TwoPaneLayout/library/build.gradle
+++ b/TwoPaneLayout/library/build.gradle
@@ -21,10 +21,6 @@ android {
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode rootProject.ext.twoPaneLayoutVersionCode
-        versionName rootProject.ext.twoPaneLayoutVersionName
-        buildConfigField("int", "VERSION_CODE", "${defaultConfig.versionCode}")
-        buildConfigField("String", "VERSION_NAME", "\"${defaultConfig.versionName}\"")
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/TwoPaneLayout/library/src/androidTest/java/com/microsoft/device/dualscreen/twopanelayout/LayoutTest.kt
+++ b/TwoPaneLayout/library/src/androidTest/java/com/microsoft/device/dualscreen/twopanelayout/LayoutTest.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import com.microsoft.device.dualscreen.windowstate.WindowState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -109,10 +108,10 @@ open class LayoutTest {
         val pane1SizePx: Size
         val pane2SizePx: Size
         with(LocalDensity.current) {
-            val pane1SizeDp = windowState.pane1SizeDp()
-            val pane2SizeDp = windowState.pane2SizeDp()
-            pane1SizePx = Size(pane1SizeDp.width.dp.toPx(), pane1SizeDp.height.dp.toPx())
-            pane2SizePx = Size(pane2SizeDp.width.dp.toPx(), pane2SizeDp.height.dp.toPx())
+            val pane1SizeDp = windowState.pane1SizeDp
+            val pane2SizeDp = windowState.pane2SizeDp
+            pane1SizePx = Size(pane1SizeDp.width.toPx(), pane1SizeDp.height.toPx())
+            pane2SizePx = Size(pane2SizeDp.width.toPx(), pane2SizeDp.height.toPx())
         }
 
         val measurePolicy = twoPaneMeasurePolicy(

--- a/TwoPaneLayout/library/src/androidTest/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneTest.kt
+++ b/TwoPaneLayout/library/src/androidTest/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneTest.kt
@@ -6,7 +6,6 @@
 package com.microsoft.device.dualscreen.twopanelayout
 
 import android.graphics.Rect
-import android.graphics.RectF
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -14,6 +13,7 @@ import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.IntSize
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.microsoft.device.dualscreen.windowstate.WindowMode
@@ -135,7 +135,7 @@ class TwoPaneTest : LayoutTest() {
         val constraints = Constraints(width, width, height, height)
         var widthDp: Dp
         var heightDp: Dp
-        var hingeBoundsDp: RectF
+        var hingeBoundsDp: DpRect
 
         val drawLatch = CountDownLatch(2)
         val childSize = arrayOfNulls<IntSize>(2)
@@ -145,12 +145,12 @@ class TwoPaneTest : LayoutTest() {
                 widthDp = width.toDp()
                 heightDp = height.toDp()
 
-                val left = hingeBounds.left.toDp().value
-                val top = hingeBounds.top.toDp().value
-                val right = hingeBounds.right.toDp().value
-                val bottom = hingeBounds.bottom.toDp().value
+                val left = hingeBounds.left.toDp()
+                val top = hingeBounds.top.toDp()
+                val right = hingeBounds.right.toDp()
+                val bottom = hingeBounds.bottom.toDp()
 
-                hingeBoundsDp = RectF(left, top, right, bottom)
+                hingeBoundsDp = DpRect(left, top, right, bottom)
             }
 
             Container(width = width, height = height) {

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -65,6 +64,7 @@ fun TwoPaneLayout(
 
     if (isSinglePane) {
         SinglePaneContainer(
+            navController = rememberNavController(),
             pane1 = pane1,
             pane2 = pane2
         )
@@ -106,11 +106,10 @@ private sealed class Screen(val route: String) {
  */
 @Composable
 internal fun SinglePaneContainer(
+    navController: NavHostController,
     pane1: @Composable TwoPaneScope.() -> Unit,
     pane2: @Composable TwoPaneScope.() -> Unit
 ) {
-    val navController = rememberNavController()
-
     NavHost(
         navController = navController,
         startDestination = currentSinglePane
@@ -147,11 +146,12 @@ private fun TwoPaneContainer(
     val pane1SizePx: Size
     val pane2SizePx: Size
     with(LocalDensity.current) {
-        val pane1SizeDp = windowState.pane1SizeDp()
-        val pane2SizeDp = windowState.pane2SizeDp()
-        pane1SizePx = Size(pane1SizeDp.width.dp.toPx(), pane1SizeDp.height.dp.toPx())
-        pane2SizePx = Size(pane2SizeDp.width.dp.toPx(), pane2SizeDp.height.dp.toPx())
+        pane1SizePx = windowState.pane1SizeDp.toSize()
+        pane2SizePx = windowState.pane2SizeDp.toSize()
     }
+
+    navigateToPane1Handler = { }
+    navigateToPane2Handler = { }
 
     val measurePolicy = twoPaneMeasurePolicy(
         windowMode = windowState.windowMode,

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -65,7 +64,6 @@ fun TwoPaneLayout(
 
     if (isSinglePane) {
         SinglePaneContainer(
-            navController = rememberNavController(),
             pane1 = pane1,
             pane2 = pane2
         )
@@ -107,10 +105,11 @@ private sealed class Screen(val route: String) {
  */
 @Composable
 internal fun SinglePaneContainer(
-    navController: NavHostController,
     pane1: @Composable TwoPaneScope.() -> Unit,
     pane2: @Composable TwoPaneScope.() -> Unit
 ) {
+    val navController = rememberNavController()
+
     NavHost(
         navController = navController,
         startDestination = currentSinglePane

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController


### PR DESCRIPTION
Resets the navigation pane handlers to empty lambdas when using TwoPaneContainer

Closes #8 