### PR TITLE
Update ComposeTesting readme

### DIFF
--- a/ComposeTesting/README.md
+++ b/ComposeTesting/README.md
@@ -1,6 +1,8 @@
 # ComposeTesting - Surface Duo Compose SDK
 
-**ComposeTesting** provides some helper functions that help you easily test your application on the dual-screen, foldable and large screen devices, by simulating the foldingFeatures(fold/hinge), device gestures, screenshot comparing and zooming.
+**ComposeTesting** provides some helper functions that help you easily test your application on dual-screen, foldable, and large screen devices by simulating folding features (fold/hinge) and device gestures.
+
+The library is based on the [testing-kotlin](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils) library and exposes those utility methods as well, so if your project uses a combination of composables and views, you only need to import **ComposeTesting**.
 
 ## Add to your project
 
@@ -16,7 +18,7 @@
 2. Add dependencies to the module-level **build.gradle** file (current version may be different from what's shown here).
 
     ```gradle
-    implementation "com.microsoft.device.dualscreen.testing:testing-compose:1.0.0-alpha02"
+    implementation "com.microsoft.device.dualscreen.testing:testing-compose:1.0.0-alpha03"
     ```
 
 3. Also ensure the compileSdkVersion and targetSdkVersion are set to API 31 or newer in the module-level build.gradle file.
@@ -36,17 +38,24 @@
 
 ## API reference
 
+For API reference information for **testing-kotlin** , refer to these resources:
 
-### FoldingFeature Helper
+- [UiDevice Extensions](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#uidevice-extensions)
+- [FoldingFeatureHelper](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#foldingfeaturehelper)
+- [DeviceModel](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#devicemodel)
+- [WindowLayoutInfoConsumer](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#windowlayoutinfoconsumer)
+- [CurrentActivityDelegate](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#currentactivitydelegate)
+- [ForceClick](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#forceclick)
+- [ViewMatcher](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#viewmatcher)
 
-These functions can be used in foldable UI tests to simulate the present of vertical and
-horizontal foldingFeatures(folds/hinges). The foldingFeatures are simulated using TestWindowLayoutInfo, using the Google [Jetpack WindowManager Testing](https://developer.android.com/reference/androidx/window/testing/layout/package-summary) library.
+In addition to the resources above, **ComposeTesting** also offers the APIs described below.
 
-```kotlin
-fun createWindowLayoutInfoPublisherRule(): TestRule
-```
+### FoldingFeatureHelper
 
-Return WindowLayoutInfoPublisherRule which allows you to simulate the different foldingFeature by pushing through different WindowLayoutInfo values.
+These functions provide Compose wrappers for the [FoldingFeatureHelper](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#foldingfeaturehelper) methods from **testing-kotlin**. The methods can be used in foldable UI tests to simulate the present of vertical and
+horizontal folding features (folds/hinges). The folding features are simulated using `TestWindowLayoutInfo` from Google's [Jetpack WindowManager Testing](https://developer.android.com/reference/androidx/window/testing/layout/package-summary) library.
+
+As described in the **testing-kotlin** documentation, the first step is to create a test rule with the `createWindowLayoutInfoPublisherRule()` function.
 
 ```kotlin
 fun <A : ComponentActivity> TestRule.simulateVerticalFoldingFeature(
@@ -57,7 +66,7 @@ fun <A : ComponentActivity> TestRule.simulateVerticalFoldingFeature(
 )
 ```
 
-Simulate a vertical foldingFeature in a Compose test
+Simulate a vertical folding feature in a Compose test. The default parameters create a vertical folding feature that is centered, 0px wide, and in the half-opened state, but these properties can be changed by passing in different parameter values.
 
 ```kotlin
 fun <A : ComponentActivity> TestRule.simulateHorizontalFoldingFeature(
@@ -68,75 +77,9 @@ fun <A : ComponentActivity> TestRule.simulateHorizontalFoldingFeature(
 )
 ```
 
-Simulate a horizontal foldingFeature in a Compose test
+Simulate a horizontal foldingFeature in a Compose test. The default parameters create a horizontal folding feature that is centered, 0px tall, and in the half-opened state, but these properties can be changed by passing in different parameter values.
 
-```kotlin
-fun <A : ComponentActivity> TestRule.simulateFoldingFeature(
-    composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<A>, A>,
-    center: Int,
-    size: Int,
-    state: FoldingFeature.State,
-    orientation: FoldingFeature.Orientation,
-) 
-```
-
-Simulate a foldingFeature with the given properties in a Compose test
-
-### Swipe Helper
-
-These functions can be used in dual-screen UI tests to simulate swipe gestures that affect
-app display. The swipes are simulated using UiDevice, and the coordinates are calculated based
-on the display width/height of the testing device. They can be used only on dual-screen devices, not foldable devices or large screen devices.
-
-```kotlin
-fun UiDevice.spanFromStart()
-```
-
-Span app from the top/left pane
-
-```kotlin
-fun UiDevice.spanFromEnd()
-```
-
-Span app from the bottom/right pane
-
-```kotlin
-fun UiDevice.unspanToStart()
-```
-
-Unspan app to the top/left pane
-
-```kotlin
-fun UiDevice.unspanToEnd()
-```
-
-Unspan app to bottom/right pane
-
-```kotlin
-fun UiDevice.switchToStart()
-```
-
-Switch app from bottom/right pane to top/left pane
-
-```kotlin
-fun UiDevice.switchToEnd() 
-```
-
-Switch app from top/left pane to bottom/right pane
-
-```kotlin
-fun UiDevice.closeStart() 
-```
-
-Close app from top/left pane
-
-```kotlin
-fun UiDevice.closeEnd()
-```
-
-Close app from bottom/right pane
-
-### String Helper
+### StringHelper
 
 These functions can be used for string operations in UI tests to simplify testing code.
 

--- a/ComposeTesting/README.md
+++ b/ComposeTesting/README.md
@@ -50,7 +50,7 @@ For API reference information for **testing-kotlin** , refer to these resources:
 
 In addition to the resources above, **ComposeTesting** also offers the APIs described below.
 
-> **Note:** When updating to version `1.0.0-alpha03` and beyond, the import statements for utility functions change from `com.microsoft.device.dualscreen.testing.<function>` to `com.microsoft.device.dualscreen.testing.compose.<function>`. The `compose` part was added to the package name to avoid conflicts with the **testing-kotlin** library.
+> **Note:** All **testing-kotlin** functions are under the `com.microsoft.device.dualscreen.testing` package, while all **ComposeTesting** functions are under a different package, called `com.microsoft.device.dualscreen.testing.compose`. Please make sure you're importing the correct version of a function in your projects.
 
 ### FoldingFeatureHelper
 

--- a/ComposeTesting/README.md
+++ b/ComposeTesting/README.md
@@ -50,6 +50,8 @@ For API reference information for **testing-kotlin** , refer to these resources:
 
 In addition to the resources above, **ComposeTesting** also offers the APIs described below.
 
+> **Note:** When updating to version `1.0.0-alpha03` and beyond, the import statements for utility functions change from `com.microsoft.device.dualscreen.testing.<function>` to `com.microsoft.device.dualscreen.testing.compose.<function>`. The `compose` part was added to the package name to avoid conflicts with the **testing-kotlin** library.
+
 ### FoldingFeatureHelper
 
 These functions provide Compose wrappers for the [FoldingFeatureHelper](https://github.com/microsoft/surface-duo-sdk/tree/main/utils/test-utils#foldingfeaturehelper) methods from **testing-kotlin**. The methods can be used in foldable UI tests to simulate the present of vertical and

--- a/ComposeTesting/library/src/main/java/com/microsoft/device/dualscreen/testing/compose/FoldingFeatureHelper.kt
+++ b/ComposeTesting/library/src/main/java/com/microsoft/device/dualscreen/testing/compose/FoldingFeatureHelper.kt
@@ -9,7 +9,11 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.window.layout.FoldingFeature
+import com.microsoft.device.dualscreen.testing.simulateFlipDevice
+import com.microsoft.device.dualscreen.testing.simulateFoldDevice
 import com.microsoft.device.dualscreen.testing.simulateHorizontalFoldingFeature
+import com.microsoft.device.dualscreen.testing.simulateSurfaceDuo1
+import com.microsoft.device.dualscreen.testing.simulateSurfaceDuo2
 import com.microsoft.device.dualscreen.testing.simulateVerticalFoldingFeature
 import org.junit.rules.TestRule
 
@@ -17,16 +21,17 @@ import org.junit.rules.TestRule
  * COMPOSE FOLDINGFEATURE HELPER
  * -----------------------------------------------------------------------------------------------
  * These functions can be used in Compose foldable UI tests to simulate the present of vertical and
- * horizontal foldingFeatures(folds/hinges). The foldingFeatures are simulated using TestWindowLayoutInfo.
+ * horizontal folding features (folds/hinges). The folding features are simulated using TestWindowLayoutInfo from
+ * Google's Jetpack Window Manager testing library.
  */
 
 /**
- * Simulate a vertical foldingFeature in a Compose test
+ * Simulate a vertical folding feature in a Compose test
  *
  * @param composeTestRule: Compose android test rule
- * @param center: location of center of foldingFeature
- * @param size: size of foldingFeature
- * @param state: state of foldingFeature
+ * @param center: location of center of folding feature
+ * @param size: size of folding feature
+ * @param state: state of folding feature
  */
 fun <A : ComponentActivity> TestRule.simulateVerticalFoldingFeature(
     composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<A>, A>,
@@ -38,12 +43,12 @@ fun <A : ComponentActivity> TestRule.simulateVerticalFoldingFeature(
 }
 
 /**
- * Simulate a horizontal foldingFeature in a Compose test
+ * Simulate a horizontal folding feature in a Compose test
  *
  * @param composeTestRule: Compose android test rule
- * @param center: location of center of foldingFeature
- * @param size: size of foldingFeature
- * @param state: state of foldingFeature
+ * @param center: location of center of folding feature
+ * @param size: size of folding feature
+ * @param state: state of folding feature
  */
 fun <A : ComponentActivity> TestRule.simulateHorizontalFoldingFeature(
     composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<A>, A>,
@@ -52,4 +57,60 @@ fun <A : ComponentActivity> TestRule.simulateHorizontalFoldingFeature(
     state: FoldingFeature.State = FoldingFeature.State.HALF_OPENED
 ) {
     simulateHorizontalFoldingFeature(composeTestRule.activityRule, center, size, state)
+}
+
+/**
+ * Simulate a folding feature with the dimensions from the Surface Duo 1 (centered, 84px hinge)
+ *
+ * @param composeTestRule: Compose android test rule
+ * @param state: state of folding feature
+ * @param orientation: orientation of folding feature
+ */
+fun <A : ComponentActivity> TestRule.simulateSurfaceDuo1(
+    composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<A>, A>,
+    state: FoldingFeature.State = FoldingFeature.State.FLAT,
+    orientation: FoldingFeature.Orientation = FoldingFeature.Orientation.VERTICAL
+) {
+    simulateSurfaceDuo1(composeTestRule.activityRule, state, orientation)
+}
+
+/**
+ * Simulate a folding feature with the dimensions from the Surface Duo 2 (centered, 66px hinge)
+ *
+ * @param composeTestRule: Compose android test rule
+ * @param state: state of folding feature
+ * @param orientation: orientation of folding feature
+ */
+fun <A : ComponentActivity> TestRule.simulateSurfaceDuo2(
+    composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<A>, A>,
+    state: FoldingFeature.State = FoldingFeature.State.FLAT,
+    orientation: FoldingFeature.Orientation = FoldingFeature.Orientation.VERTICAL
+) {
+    simulateSurfaceDuo2(composeTestRule.activityRule, state, orientation)
+}
+
+/**
+ * Simulate a folding feature with the dimensions from a Fold device (centered, vertical, 0px fold)
+ *
+ * @param composeTestRule: Compose android test rule
+ * @param state: state of folding feature
+ */
+fun <A : ComponentActivity> TestRule.simulateFoldDevice(
+    composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<A>, A>,
+    state: FoldingFeature.State = FoldingFeature.State.HALF_OPENED
+) {
+    simulateFoldDevice(composeTestRule.activityRule, state)
+}
+
+/**
+ * Simulate a folding feature with the dimensions from a Flip device (centered, horizontal, 0px fold)
+ *
+ * @param composeTestRule: Compose android test rule
+ * @param state: state of folding feature
+ */
+fun <A : ComponentActivity> TestRule.simulateFlipDevice(
+    composeTestRule: AndroidComposeTestRule<ActivityScenarioRule<A>, A>,
+    state: FoldingFeature.State = FoldingFeature.State.HALF_OPENED
+) {
+    simulateFlipDevice(composeTestRule.activityRule, state)
 }

--- a/README.md
+++ b/README.md
@@ -42,17 +42,14 @@ Helper functions that help you easily test your application on the dual-screen, 
 
 ## Social links
 
-- [video: Jetpack Compose WindowState preview](https://www.youtube.com/watch?v=qOIliow-uS4)
-- [blog: Jetpack Compose WindowState preview](https://devblogs.microsoft.com/surface-duo/jetpack-compose-windowstate-preview/)
-- [video: Get started with Jetpack Compose Twitch](https://www.youtube.com/watch?v=ijXDWDtdiIE)
-- [blog: Get started with Jetpack Compose](https://devblogs.microsoft.com/surface-duo/get-started-with-jetpack-compose/)
-- [video: NavigationRail Compose sample Twitch](https://www.youtube.com/watch?v=pdoIyOU7Suk)
-- [blog: NavigationRail Compose sample](https://devblogs.microsoft.com/surface-duo/jetpack-compose-navigation-rail/)
-- [video: TwoPaneLayout Compose library Twitch](https://www.youtube.com/watch?v=Q66bR2jKdrg)
-- [blog: New TwoPaneLayout Compose library preview](https://devblogs.microsoft.com/surface-duo/jetpack-compose-twopanelayout-preview/)
-- [video: Jetpack Compose samples Twitch](https://www.youtube.com/watch?v=m8bMjFhBbN8)
-- [blog: Jetpack Compose foldable and dual-screen development](https://devblogs.microsoft.com/surface-duo/jetpack-compose-foldable-samples)
-- [blog: Jetpack Compose on Microsoft Surface Duo](https://devblogs.microsoft.com/surface-duo/jetpack-compose-dual-screen-sample/)
+| Blog post | Video |
+|---|---|
+| [Jetpack Compose WindowState preview](https://devblogs.microsoft.com/surface-duo/jetpack-compose-windowstate-preview/) | [Twitch #53: Jetpack Compose WindowState for foldable devices](https://www.youtube.com/watch?v=qOIliow-uS4) |
+| [Get started with Jetpack Compose](https://devblogs.microsoft.com/surface-duo/get-started-with-jetpack-compose/) | [Twitch #44: Get started with Jetpack Compose](https://www.youtube.com/watch?v=ijXDWDtdiIE) |
+| [Jetpack Compose Navigation Rail](https://devblogs.microsoft.com/surface-duo/jetpack-compose-navigation-rail/) | [Twitch #42: Jetpack Compose Navigation Rail](https://www.youtube.com/watch?v=pdoIyOU7Suk)
+| [New TwoPaneLayout Compose library preview](https://devblogs.microsoft.com/surface-duo/jetpack-compose-twopanelayout-preview/) | [Twitch #25: TwoPaneLayout preview for Jetpack Compose](https://www.youtube.com/watch?v=Q66bR2jKdrg) |
+| [Jetpack Compose foldable and dual-screen development](https://devblogs.microsoft.com/surface-duo/jetpack-compose-foldable-samples) | [Twitch #9: Jetpack Compose samples](https://www.youtube.com/watch?v=m8bMjFhBbN8) |
+| [Jetpack Compose on Microsoft Surface Duo](https://devblogs.microsoft.com/surface-duo/jetpack-compose-dual-screen-sample/) | N/A|
 
 ## Related links
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A utility component that helps you easily get details about the window state of 
 
 Helper functions that help you easily test your application on the dual-screen, foldable and large screen devices.
 
-#### Latest Update: [1.0.0-alpha02](https://github.com/microsoft/surface-duo-compose-sdk/releases/tag/composetesting_20220211_alpha02) (February 11th, 2022)
+#### Latest Update: [1.0.0-alpha03](https://github.com/microsoft/surface-duo-compose-sdk/releases/tag/composetesting_20220301_alpha03) (March 1st, 2022)
 
 ## Social links
 

--- a/TwoPaneLayout/dependencies.gradle
+++ b/TwoPaneLayout/dependencies.gradle
@@ -82,7 +82,7 @@ ext {
 
     // Microsoft dependencies
     windowStateVersion = '1.0.0-alpha04'
-    composeTestingVersion = '1.0.0-alpha02'
+    composeTestingVersion = '1.0.0-alpha03'
     microsoftDependencies = [
             windowState         : "com.microsoft.device.dualscreen:windowstate:$windowStateVersion",
             composeTesting      : "com.microsoft.device.dualscreen.testing:testing-compose:$composeTestingVersion",

--- a/TwoPaneLayout/sample/src/androidTest/java/com/microsoft/device/dualscreen/twopanelayout/SampleTest.kt
+++ b/TwoPaneLayout/sample/src/androidTest/java/com/microsoft/device/dualscreen/twopanelayout/SampleTest.kt
@@ -9,10 +9,10 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.microsoft.device.dualscreen.testing.compose.getString
+import com.microsoft.device.dualscreen.testing.compose.simulateHorizontalFoldingFeature
+import com.microsoft.device.dualscreen.testing.compose.simulateVerticalFoldingFeature
 import com.microsoft.device.dualscreen.testing.createWindowLayoutInfoPublisherRule
-import com.microsoft.device.dualscreen.testing.getString
-import com.microsoft.device.dualscreen.testing.simulateHorizontalFoldingFeature
-import com.microsoft.device.dualscreen.testing.simulateVerticalFoldingFeature
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test


### PR DESCRIPTION
Updates two readmes:
1. Repo readme with the latest release version + a new table format for social links
2. ComposeTesting readme with updated API reference info

Also realized that I forgot to add Compose wrappers for the market device folding feature methods, so this includes that update (no need to release another library version now, we can wait until we have another dependency update or API change)