### PR TITLE
Update TwoPaneLayout navigation with the new Compose Nav library

### DIFF
--- a/TwoPaneLayout/dependencies.gradle
+++ b/TwoPaneLayout/dependencies.gradle
@@ -54,7 +54,7 @@ ext {
     // Compose dependencies
     composeVersion = "1.1.1"
     activityComposeVersion = "1.4.0"
-    navigationComposeVersion = "2.4.0"
+    navigationComposeVersion = "2.4.2"
     composeDependencies = [
             composeMaterial         : "androidx.compose.material:material:$composeVersion",
             composeUI               : "androidx.compose.ui:ui:$composeVersion",

--- a/TwoPaneLayout/dependencies.gradle
+++ b/TwoPaneLayout/dependencies.gradle
@@ -14,11 +14,11 @@ ext {
 
     // TwoPaneLayout library version code:
     // If you want to publish a new version, bump in one (1) the specific line(s)
-    twoPaneLayoutVersionCode = 14
+    twoPaneLayoutVersionCode = 15
 
     // TwoPaneLayout library version name:
     // If you want to publish a new version, bump the specific line
-    twoPaneLayoutVersionName = '1.0.0-beta04'
+    twoPaneLayoutVersionName = '1.0.0-beta05'
 
     // ----------------------------------
 

--- a/TwoPaneLayout/library/src/androidTest/java/com/microsoft/device/dualscreen/twopanelayout/LayoutTest.kt
+++ b/TwoPaneLayout/library/src/androidTest/java/com/microsoft/device/dualscreen/twopanelayout/LayoutTest.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
-import androidx.navigation.NavHostController
 import com.microsoft.device.dualscreen.windowstate.WindowState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -93,11 +92,10 @@ open class LayoutTest {
 
     @Composable
     internal fun MockSinglePaneLayout(
-        navController: NavHostController,
         firstPane: @Composable TwoPaneScope.() -> Unit,
         secondPane: @Composable TwoPaneScope.() -> Unit
     ) {
-        SinglePaneContainer(navController, firstPane, secondPane)
+        SinglePaneContainer(firstPane, secondPane)
     }
 
     @Composable

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
@@ -10,10 +10,6 @@ import androidx.compose.foundation.layout.LayoutScopeMarker
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.Layout
@@ -157,31 +153,27 @@ internal fun SinglePaneContainer(
         }
     }
 
-    var topPane: String? by rememberSaveable { mutableStateOf(null) }
-    if (!navController.backQueue.isEmpty()) {
-        topPane = navController.backQueue.last().destination.route
-    }
-
     navigateToPane1Handler = {
         if (!navController.backQueue.isEmpty()) {
-            topPane = navController.backQueue.last().destination.route
+            val topPane = navController.backQueue.last().destination.route
+
+            // Navigate only when pane1 is not shown(not at the top of the backstack)
+            if (topPane != Screen.Pane1.route) {
+                navController.popBackStack()
+            }
         }
 
-        // Navigate only when pane1 is not shown(not at the top of the backstack)
-        if (topPane != Screen.Pane1.route) {
-            navController.popBackStack()
-        }
         currentSinglePane = Screen.Pane1.route
     }
 
     navigateToPane2Handler = {
         if (!navController.backQueue.isEmpty()) {
-            topPane = navController.backQueue.last().destination.route
-        }
+            val topPane = navController.backQueue.last().destination.route
 
-        // Navigate only when pane2 is not shown(not at the top of the backstack)
-        if (topPane != Screen.Pane2.route) {
-            navController.navigate(Screen.Pane2.route)
+            // Navigate only when pane2 is not shown(not at the top of the backstack)
+            if (topPane != Screen.Pane2.route) {
+                navController.navigate(Screen.Pane2.route)
+            }
         }
         currentSinglePane = Screen.Pane2.route
     }

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
@@ -113,8 +113,8 @@ fun isPane1Shown(): Boolean {
  */
 lateinit var twoPaneNavController: NavHostController
 
-private lateinit var navigateToPane1Handler: () -> Unit
-private lateinit var navigateToPane2Handler: () -> Unit
+private var navigateToPane1Handler: () -> Unit = {}
+private var navigateToPane2Handler: () -> Unit = {}
 
 /**
  * The route of the pane shown in the SinglePaneContainer

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/TwoPaneLayout.kt
@@ -64,7 +64,6 @@ fun TwoPaneLayout(
     pane1: @Composable TwoPaneScope.() -> Unit,
     pane2: @Composable TwoPaneScope.() -> Unit
 ) {
-    twoPaneNavController = rememberNavController()
     val activity = (LocalContext.current as? Activity)
         ?: throw ClassCastException("Local context could not be cast as an Activity")
     val windowState = activity.rememberWindowState()
@@ -73,7 +72,6 @@ fun TwoPaneLayout(
 
     if (isSinglePane) {
         SinglePaneContainer(
-            navController = twoPaneNavController,
             pane1 = pane1,
             pane2 = pane2
         )
@@ -141,10 +139,11 @@ private sealed class Screen(val route: String) {
  */
 @Composable
 internal fun SinglePaneContainer(
-    navController: NavHostController,
     pane1: @Composable TwoPaneScope.() -> Unit,
     pane2: @Composable TwoPaneScope.() -> Unit
 ) {
+    val navController = rememberNavController()
+    twoPaneNavController = navController
     currentSinglePane = Screen.Pane1.route // always start from Pane1 to maintain the expected backstack
     NavHost(
         navController = navController,


### PR DESCRIPTION
<!---
Update TwoPaneLayout navigation with the new Compose Nav library
-->

## 📃 Description
- Update ComposeNavigation to v2.4.2
- Navigate based on the top pane of the backstack
- Initial the navigate handler to avoid the unnecessary un-initialized issue
- Create navController inside the singlePaneContainer to avoid unnecessary recreation during the recomposition

## 🤔 Motivation and Context
- use the top pane of the backstack from the systme instead of counting on our own currentSinglePane
- Start from Pane1 no matter what to maintain the expected nav graph

## 🧪 How Has This Been Tested?
Manual test on the device

## ⚒️ Does the PR contain new tests or refactored old ones?
NA

## 📷 Screenshots (if appropriate)
NA
## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement to a current functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bug fix (non-breaking change which fixes an issue. Please add issue link here too).

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] This PR contains new tests that cover the new code.
- [x] This PR refactor previous tests to cover the new code.
- [ ] This PR is part of a set of PRs that build a bigger feature. If so, please, add here links to previously merged or open PRs.

<!-- 
Credits: 
- [Cortinico](https://github.com/cortinico/kotlin-android-template/tree/main/.github)
- [Fluent UI team](https://github.com/microsoft/fluentui-android/tree/master/.github) 
- 
for their fantastic templates that have helped us as inspiration.
-->