### PR TITLE
Remove usage of private backQueue field

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A Compose component that helps you build drag and drop feature on any Android de
 
 | Blog post | Video |
 |---|---|
+| [Improved navigation support in TwoPaneLayout](https://devblogs.microsoft.com/surface-duo/twopanelayout-navigation/) | N/A |
 | [Blossoming love for Compose animation](https://devblogs.microsoft.com/surface-duo/jetpack-compose-animation-3/) | [Twitch #105: Jetpack Compose animations](https://www.youtube.com/watch?v=8ql2CDpx6lk) |
 | [Blooming love for Compose animation](https://devblogs.microsoft.com/surface-duo/jetpack-compose-animation-2/) | _see above_ |
 | [Budding love for Compose animation](https://devblogs.microsoft.com/surface-duo/jetpack-compose-animation-1/) | _see above_ |

--- a/TwoPaneLayout/README.md
+++ b/TwoPaneLayout/README.md
@@ -20,7 +20,7 @@ When the app is spanned across a separating vertical hinge or fold, or when the 
 2. Add dependencies to the module-level **build.gradle** file (current version may be different from what's shown here).
 
     ```gradle
-    implementation "com.microsoft.device.dualscreen:twopanelayout:1.0.1-alpha07"
+    implementation "com.microsoft.device.dualscreen:twopanelayout:1.0.1-alpha08"
     ```
 
 3. Also ensure the compileSdkVersion is set to API 33 and the targetSdkVersion is set to API 32 or newer in the module-level **build.gradle** file.

--- a/TwoPaneLayout/dependencies.gradle
+++ b/TwoPaneLayout/dependencies.gradle
@@ -56,7 +56,7 @@ ext {
     composeMaterialVersion = '1.4.3'
     composeCompilerVersion = '1.4.7'
     activityComposeVersion = '1.7.1'
-    navigationComposeVersion = '2.5.3'
+    navigationComposeVersion = '2.6.0'
     composeDependencies = [
             composeMaterial         : "androidx.compose.material:material:$composeMaterialVersion",
             composeUI               : "androidx.compose.ui:ui:$composeVersion",

--- a/TwoPaneLayout/dependencies.gradle
+++ b/TwoPaneLayout/dependencies.gradle
@@ -14,11 +14,11 @@ ext {
 
     // TwoPaneLayout library version code:
     // If you want to publish a new version, bump in one (1) the specific line(s)
-    twoPaneLayoutVersionCode = 23
+    twoPaneLayoutVersionCode = 24
 
     // TwoPaneLayout library version name:
     // If you want to publish a new version, bump the specific line
-    twoPaneLayoutVersionName = '1.0.1-alpha07'
+    twoPaneLayoutVersionName = '1.0.1-alpha08'
 
     // ----------------------------------
 

--- a/TwoPaneLayout/dependencies.gradle
+++ b/TwoPaneLayout/dependencies.gradle
@@ -45,7 +45,7 @@ ext {
 
     // AndroidX dependencies
     appCompatVersion = '1.6.1'
-    ktxCoreVersion = '1.10.0'
+    ktxCoreVersion = '1.10.1'
     androidxDependencies = [
             appCompat         : "androidx.appcompat:appcompat:$appCompatVersion",
             ktxCore           : "androidx.core:core-ktx:$ktxCoreVersion",
@@ -55,7 +55,7 @@ ext {
     composeVersion = '1.4.3'
     composeMaterialVersion = '1.4.3'
     composeCompilerVersion = '1.4.7'
-    activityComposeVersion = '1.7.1'
+    activityComposeVersion = '1.7.2'
     navigationComposeVersion = '2.6.0'
     composeDependencies = [
             composeMaterial         : "androidx.compose.material:material:$composeMaterialVersion",
@@ -78,7 +78,7 @@ ext {
     ]
 
     // Google dependencies
-    materialVersion = '1.8.0'
+    materialVersion = '1.9.0'
     googleDependencies = [
             material: "com.google.android.material:material:$materialVersion"
     ]

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/twopanelayout/TwoPaneLayoutCore.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/twopanelayout/TwoPaneLayoutCore.kt
@@ -57,25 +57,21 @@ internal fun SinglePaneContainer(
     }
 
     navigateToPane1Handler = {
-        if (!navController.backQueue.isEmpty()) {
-            val topPane = navController.backQueue.last().destination.route
+        val topPane = navController.currentDestination?.route
 
-            // Navigate only when pane1 is not shown(not at the top of the backstack)
-            if (topPane != Screen.Pane1.route) {
-                navController.popBackStack()
-            }
+        // Navigate only when pane1 is not shown(not at the top of the backstack)
+        if (topPane?.let { it != Screen.Pane1.route } == true) {
+            navController.popBackStack()
         }
         currentSinglePane = Screen.Pane1.route
     }
 
     navigateToPane2Handler = {
-        if (!navController.backQueue.isEmpty()) {
-            val topPane = navController.backQueue.last().destination.route
+        val topPane = navController.currentDestination?.route
 
-            // Navigate only when pane2 is not shown (not at the top of the backstack)
-            if (topPane != Screen.Pane2.route) {
-                navController.navigate(Screen.Pane2.route)
-            }
+        // Navigate only when pane2 is not shown (not at the top of the backstack)
+        if (topPane?.let { it != Screen.Pane2.route } == true) {
+            navController.navigate(Screen.Pane2.route)
         }
         currentSinglePane = Screen.Pane2.route
     }

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/twopanelayout/TwoPaneLayoutCore.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/twopanelayout/TwoPaneLayoutCore.kt
@@ -60,7 +60,7 @@ internal fun SinglePaneContainer(
         val topPane = navController.currentDestination?.route
 
         // Navigate only when pane1 is not shown(not at the top of the backstack)
-        if (topPane?.let { it != Screen.Pane1.route } == true) {
+        if (topPane != Screen.Pane1.route) {
             navController.popBackStack()
         }
         currentSinglePane = Screen.Pane1.route
@@ -70,7 +70,7 @@ internal fun SinglePaneContainer(
         val topPane = navController.currentDestination?.route
 
         // Navigate only when pane2 is not shown (not at the top of the backstack)
-        if (topPane?.let { it != Screen.Pane2.route } == true) {
+        if (topPane != Screen.Pane2.route) {
             navController.navigate(Screen.Pane2.route)
         }
         currentSinglePane = Screen.Pane2.route

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/twopanelayoutnav/TwoPaneLayoutNavCore.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/twopanelayoutnav/TwoPaneLayoutNavCore.kt
@@ -94,7 +94,7 @@ internal fun SinglePaneContainer(
         val topDestination = currentDestination?.route
 
         // Navigate only when necessary
-        if (topDestination?.let { it != route } == true) {
+        if (topDestination != route) {
             navigate(route, navOptions)
             currentSinglePane = route
         }

--- a/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/twopanelayoutnav/TwoPaneLayoutNavCore.kt
+++ b/TwoPaneLayout/library/src/main/java/com/microsoft/device/dualscreen/twopanelayout/twopanelayoutnav/TwoPaneLayoutNavCore.kt
@@ -91,10 +91,10 @@ internal fun SinglePaneContainer(
     var currentSinglePane by remember { mutableStateOf(startDestination) }
     getSinglePaneDestination = { currentSinglePane }
     navigateSinglePaneTo = { route, navOptions ->
-        val topDestination = backQueue.lastOrNull()?.destination?.route
+        val topDestination = currentDestination?.route
 
         // Navigate only when necessary
-        if (topDestination != route) {
+        if (topDestination?.let { it != route } == true) {
             navigate(route, navOptions)
             currentSinglePane = route
         }


### PR DESCRIPTION
<!---
Instructions: Please, fill the following sections with the information that is suggested in the comments. You can leave the comments or delete them, it won't be shown in the PR.
-->

## 📃 Description
<!-- Describe your changes in detail -->
Update dependencies and removes usage of the `navController.backQueue` field, which was made private in `navigation-compose` version `2.6.0`.

## 🤔 Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Addresses bug #63 

## 🧪 How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how your change affects other areas of the code, etc. -->
Ran all existing tests and manually tested behavior with library samples

## ⚒️ Does the PR contain new tests or refactored old ones?
<!-- Please describe in detail what your test cover or how the changes the refactored tests help to confirm your code works. -->
N/A

## 📷 Screenshots (if appropriate)
<!-- Please provide a screenshot of your change so we can see visually the change in the UI (again, if appropriate)-->
N/A

## 📦 Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement to a current functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Bug fix #63 

## ✅ Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] This PR contains new tests that cover the new code.
- [ ] This PR refactor previous tests to cover the new code.
- [ ] This PR is part of a set of PRs that build a bigger feature. If so, please, add here links to previously merged or open PRs.

<!-- 
Credits: 
- [Cortinico](https://github.com/cortinico/kotlin-android-template/tree/main/.github)
- [Fluent UI team](https://github.com/microsoft/fluentui-android/tree/master/.github) 
- 
for their fantastic templates that have helped us as inspiration.
-->